### PR TITLE
Unicode implementation to find text runs to mark

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-marked",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Plugin for markdown-it for marking substrings within text",
   "license": "Apache-2.0",
   "main": "dist/markdown-it-marked.js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "postpublish": "git push --atomic origin master $npm_package_version",
+    "postpublish": "git push --atomic origin master v$npm_package_version",
     "postversion": "npm publish",
     "prepare": "rollup --config",
     "pretest": "eslint .",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mark"
   ],
   "scripts": {
+    "coverage": "jest --coverage",
     "lint": "eslint .",
     "postpublish": "git push --atomic origin master v$npm_package_version",
     "postversion": "npm publish",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,6 @@
  * This is free software licensed as Apache-2.0 - see COPYING for terms.
  */
 
-export {envFromTerms} from './pattern.js';
+export {envFromTerms, envFromUnicodeTerms} from './pattern.js';
 
 export {markedPlugin as plugin} from './plugin.js';

--- a/src/pattern.js
+++ b/src/pattern.js
@@ -43,7 +43,7 @@ export function envFromTerms(terms, options) {
   // If terms may be suffixes, do not include boundary prefix.
   const boundaryPre = !options.suffix;
   const boundarySuf = !options.prefix;
-  const contain = boundaryPre | boundarySuf && terms.length > 1;
+  const contain = (boundaryPre | boundarySuf) & terms.length > 1;
   const pre = boundaries[contain * 2 | boundaryPre];
   const suf = boundaries[contain * 4 | boundarySuf];
 

--- a/src/pattern.js
+++ b/src/pattern.js
@@ -30,6 +30,7 @@ function buildEnv(strings, pre, suf, flags) {
 }
 
 const boundaries = ['', '\\b', '(?:', '\\b(?:', ')', ')\\b'];
+// Cc: Control Cf: forma P: Punctuation Z: Separator
 const endClasses = '|\\p{Cc}\\p{Cf}|\\p{P}|\\p{Z})';
 const unicodeParts = ['', '(?<=^' + endClasses, '(?:', ')', '(?=$' + endClasses];
 

--- a/src/pattern.js
+++ b/src/pattern.js
@@ -64,7 +64,7 @@ export function envFromUnicodeTerms(terms, options) {
   // If terms may be suffixes, do not include boundary prefix.
   const boundaryPre = !options.suffix;
   const boundarySuf = !options.prefix;
-  const contain = boundaryPre | boundarySuf && terms.length > 1;
+  const contain = (boundaryPre | boundarySuf) & terms.length > 1;
   const pre = unicodeParts[+boundaryPre] + unicodeParts[contain * 2];
   const suf = unicodeParts[contain * 3] + unicodeParts[boundarySuf * 4];
 

--- a/src/pattern.js
+++ b/src/pattern.js
@@ -30,6 +30,8 @@ function buildEnv(strings, pre, suf, flags) {
 }
 
 const boundaries = ['', '\\b', '(?:', '\\b(?:', ')', ')\\b'];
+const endClasses = '|\\p{Cc}\\p{Cf}|\\p{P}|\\p{Z})';
+const unicodeParts = ['', '(?<=^' + endClasses, '(?:', ')', '(?=$' + endClasses];
 
 export function envFromTerms(terms, options) {
   if (!terms.length) {
@@ -42,11 +44,31 @@ export function envFromTerms(terms, options) {
   const boundaryPre = !options.suffix;
   const boundarySuf = !options.prefix;
   const contain = boundaryPre | boundarySuf && terms.length > 1;
-  const pre = boundaries[(contain << 1) | boundaryPre];
-  const suf = boundaries[(contain << 2) | boundarySuf];
+  const pre = boundaries[contain * 2 | boundaryPre];
+  const suf = boundaries[contain * 4 | boundarySuf];
 
   // If exact match is required, remove 'i' flag.
   const flags = 'ig'.slice(!!options.exact);
+
+  return buildEnv(terms, pre, suf, flags);
+}
+
+export function envFromUnicodeTerms(terms, options) {
+  if (!terms.length) {
+    return {};
+  }
+  options ||= {};
+
+  // If terms may be prefixes, do not include boundary suffix.
+  // If terms may be suffixes, do not include boundary prefix.
+  const boundaryPre = !options.suffix;
+  const boundarySuf = !options.prefix;
+  const contain = boundaryPre | boundarySuf && terms.length > 1;
+  const pre = unicodeParts[+boundaryPre] + unicodeParts[contain * 2];
+  const suf = unicodeParts[contain * 3] + unicodeParts[boundarySuf * 4];
+
+  // If exact match is required, remove 'i' flag.
+  const flags = 'igu'.slice(!!options.exact);
 
   return buildEnv(terms, pre, suf, flags);
 }

--- a/test/env.js
+++ b/test/env.js
@@ -5,7 +5,7 @@
  * This is free software licensed as Apache-2.0 - see COPYING for terms.
  */
 
-import {envFromTerms} from 'markdown-it-marked';
+import {envFromTerms, envFromUnicodeTerms} from 'markdown-it-marked';
 
 describe('envFromTerms', () => {
   const completeOptions = {exact: true, prefix: true, suffix: true};
@@ -57,5 +57,58 @@ describe('envFromTerms', () => {
     [['ism', 'ship', 'tion'], {markedPattern: /(?:ship|tion|ism)\b/gi}],
   ])('prefixes %O', (words, expected) => {
     expect(envFromTerms(words, suffixOptions)).toEqual(expected);
+  });
+});
+
+describe('envFromUnicodeTerms', () => {
+  const completeOptions = {exact: true, prefix: true, suffix: true};
+  test.each([
+    [[], {}],
+    [['a'], {markedPattern: /a/gu}],
+    [['?'], {markedPattern: /\?/gu}],
+    [['.*', '.+', '()', '|$'], {markedPattern: /\.\*|\.\+|\(\)|\|\$/gu}],
+  ])('escaping %O', (strings, expected) => {
+    expect(envFromUnicodeTerms(strings, completeOptions)).toEqual(expected);
+  });
+
+  const substringOptions = {prefix: true, suffix: true};
+  test.each([
+    [['one', 'two'], {markedPattern: /one|two/giu}],
+    [['sub', 'substring'], {markedPattern: /substring|sub/giu}],
+  ])('sorting %O', (strings, expected) => {
+    expect(envFromUnicodeTerms(strings, substringOptions)).toEqual(expected);
+  });
+
+  test.each([
+    [['']],
+    [['a', '', 'z']],
+  ])('checking %O', strings => {
+    expect(() => envFromUnicodeTerms(strings)).toThrow({
+      'message': 'markdown-it-marked: zero-length word',
+    });
+  });
+
+  const fullWordOptions = {prefix: false, suffix: false};
+  test.each([
+    [['a'], {markedPattern: /(?<=^|\p{Cc}\p{Cf}|\p{P}|\p{Z})a(?=$|\p{Cc}\p{Cf}|\p{P}|\p{Z})/giu}],
+    [['it\'s', 'done.'], {markedPattern: /(?<=^|\p{Cc}\p{Cf}|\p{P}|\p{Z})(?:done\.|it's)(?=$|\p{Cc}\p{Cf}|\p{P}|\p{Z})/giu}],
+  ])('using %O', (words, expected) => {
+    expect(envFromUnicodeTerms(words, fullWordOptions)).toEqual(expected);
+  });
+
+  const prefixOptions = {prefix: true, suffix: false};
+  test.each([
+    [['pre'], {markedPattern: /(?<=^|\p{Cc}\p{Cf}|\p{P}|\p{Z})pre/giu}],
+    [['inter', 'sub', 'trans'], {markedPattern: /(?<=^|\p{Cc}\p{Cf}|\p{P}|\p{Z})(?:inter|trans|sub)/giu}],
+  ])('prefixes %O', (words, expected) => {
+    expect(envFromUnicodeTerms(words, prefixOptions)).toEqual(expected);
+  });
+
+  const suffixOptions = {prefix: false, suffix: true};
+  test.each([
+    [['er'], {markedPattern: /er(?=$|\p{Cc}\p{Cf}|\p{P}|\p{Z})/giu}],
+    [['ism', 'ship', 'tion'], {markedPattern: /(?:ship|tion|ism)(?=$|\p{Cc}\p{Cf}|\p{P}|\p{Z})/giu}],
+  ])('prefixes %O', (words, expected) => {
+    expect(envFromUnicodeTerms(words, suffixOptions)).toEqual(expected);
   });
 });

--- a/test/render.js
+++ b/test/render.js
@@ -7,7 +7,7 @@
 
 import MarkdownIt from 'markdown-it';
 
-import {envFromUnicodeTerms, plugin} from 'markdown-it-marked';
+import {envFromTerms, envFromUnicodeTerms, plugin} from 'markdown-it-marked';
 
 describe('default options', () => {
   const mi = MarkdownIt()
@@ -71,15 +71,31 @@ describe('default options', () => {
   });
 });
 
-describe('integration', () => {
+describe('envFromTerms integration', () => {
   const mi = MarkdownIt()
     .use(plugin);
 
-  const ampEnv = envFromUnicodeTerms(['a', '&', 'b']);
+  const ampEnv = envFromTerms(['a', '&', 'b', '(c)'], {prefix: true});
+  test.each([
+    ['', ''],
+    ['a & b', '<mark>a</mark> &amp; <mark>b</mark>'],
+    ['aa && bb', '<mark>a</mark>a &amp;&amp; <mark>b</mark>b'],
+    ['a & b (c)', '<mark>a</mark> &amp; <mark>b</mark> (c)'],
+  ])('real world %O in %O', (input, expected) => {
+    expect(mi.renderInline(input, ampEnv)).toEqual(expected);
+  });
+});
+
+describe('envFromUnicodeTerms integration', () => {
+  const mi = MarkdownIt()
+    .use(plugin);
+
+  const ampEnv = envFromUnicodeTerms(['a', '&', 'b', '(c)'], {prefix: true});
   test.each([
     ['', ''],
     ['a & b', '<mark>a</mark> <mark>&amp;</mark> <mark>b</mark>'],
-    ['aa && bb', 'aa <mark>&amp;</mark><mark>&amp;</mark> bb'],
+    ['aa && bb', '<mark>a</mark>a <mark>&amp;</mark><mark>&amp;</mark> <mark>b</mark>b'],
+    ['a & b (c)', '<mark>a</mark> <mark>&amp;</mark> <mark>b</mark> <mark>(c)</mark>'],
   ])('real world %O in %O', (input, expected) => {
     expect(mi.renderInline(input, ampEnv)).toEqual(expected);
   });

--- a/test/render.js
+++ b/test/render.js
@@ -7,7 +7,7 @@
 
 import MarkdownIt from 'markdown-it';
 
-import {plugin} from 'markdown-it-marked';
+import {envFromUnicodeTerms, plugin} from 'markdown-it-marked';
 
 describe('default options', () => {
   const mi = MarkdownIt()
@@ -68,5 +68,19 @@ describe('default options', () => {
     ],
   ])('block match %O in %O', (pat, input, expected) => {
     expect(mi.render(input, {markedPattern: pat})).toEqual(expected);
+  });
+});
+
+describe('integration', () => {
+  const mi = MarkdownIt()
+    .use(plugin);
+
+  const ampEnv = envFromUnicodeTerms(['a', '&', 'b']);
+  test.each([
+    ['', ''],
+    ['a & b', '<mark>a</mark> <mark>&amp;</mark> <mark>b</mark>'],
+    ['aa && bb', 'aa <mark>&amp;</mark><mark>&amp;</mark> bb'],
+  ])('real world %O in %O', (input, expected) => {
+    expect(mi.renderInline(input, ampEnv)).toEqual(expected);
   });
 });


### PR DESCRIPTION
- Added `envFromUnicodeTerms`, use `\p{Cc}\p{Cf}|\p{P}|\p{Z}` for word break. See https://www.compart.com/en/unicode/category for unicode categories reference.
- Updated `contain` to ensure the value is always 1 or 0
- Added tests in `env.js` to check `envFromUnicodeTerms` regex output work for old cases.
- Added tests in `render.js`, it can be seen in comparison that `envFromUnicodeTerms` can highlight words with special symbol at the start.

https://visual-meaning.atlassian.net/browse/SMP-395